### PR TITLE
Go 1.4 or later is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ exploit.
 Follow these steps to run the Vuvuzela system locally using the provided
 sample configs.
 
-1. Install Vuvuzela (assuming `GOPATH=~/go`):
+1. Install Vuvuzela (assuming `GOPATH=~/go`, requires Go 1.4 or later):
 
         $ go get github.com/davidlazar/vuvuzela/...
 


### PR DESCRIPTION
I got this error with go 1.2 on Ubuntu Trusty:

  # github.com/davidlazar/vuvuzela/rand
  gocode/src/github.com/davidlazar/vuvuzela/rand/cpu_amd64.s:2 6a: No such file or directory: textflag.h

I am not familiar with go but I think it's because go 1.4 or later is required?